### PR TITLE
enable replacement of edm-font-default in addition to edm-color-default

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+edm (1.12.85-3) unstable; urgency=low
+
+  * debian/control: fix dependency problem for edm-font-default
+  * add package edm-font-default
+  * debian/control: enable replacement of edm-font-default and edm-color-default
+
+ -- Joachim Rahn <Joachim.Rahn@helmholtz-berlin.de>  Thu, 15 Jan 2015 12:27:41 +0100
+
 edm (1.12.85-2) unstable; urgency=low
 
   * Apply fix for baselib/xyplot: use nan for negative log10 axis

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+edm (1.12.85-4) unstable; urgency=low
+
+  * debian/control: typo fixed
+
+ -- Joachim Rahn <Joachim.Rahn@helmholtz-berlin.de>  Thu, 15 Jan 2015 13:52:52 +0100
+
 edm (1.12.85-3) unstable; urgency=low
 
   * debian/control: fix dependency problem for edm-font-default

--- a/debian/control
+++ b/debian/control
@@ -45,7 +45,7 @@ Conflicts: edm (<= 1.12.85-2), edm-font
 Description: Extensible Display Manager
  A display manager (GUI) for the EPICS control system
  .
- This is the default colors.list which is distributed with EDM.
+ This is the default fonts.list which is distributed with EDM.
 
 Package: edm-dev
 Section: contrib/devel

--- a/debian/control
+++ b/debian/control
@@ -14,9 +14,12 @@ Homepage: http://ics-web.sns.ornl.gov/edm/
 Package: edm
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
-         netpbm, edm-color-default | edm-color,
+         netpbm, 
+         edm-color-default | edm-color, 
+         edm-font-default | edm-font
 Recommends: xfonts-75dpi,
-           edm-color-default (= ${source:Version})
+           edm-color-default (= ${source:Version}),
+           edm-font-default (= ${source:Version})
 Suggests: cups-bsd | lpr | lprng,
           edm-doc (= ${source:Version}),
 Description: Extensible Display Manager
@@ -26,7 +29,19 @@ Package: edm-color-default
 Architecture: all
 Depends: ${misc:Depends}
 Provides: edm-color
-Conflicts: edm (<< 1.12.24-1)
+Replaces: edm-color
+Conflicts: edm (<< 1.12.24-1), edm-color
+Description: Extensible Display Manager
+ A display manager (GUI) for the EPICS control system
+ .
+ This is the default colors.list which is distributed with EDM.
+
+Package: edm-font-default
+Architecture: all
+Depends: ${misc:Depends}
+Provides: edm-font
+Replaces: edm-font
+Conflicts: edm (<= 1.12.85-2), edm-font
 Description: Extensible Display Manager
  A display manager (GUI) for the EPICS control system
  .

--- a/debian/edm-font-default.install
+++ b/debian/edm-font-default.install
@@ -1,0 +1,1 @@
+etc/edm/fonts.list

--- a/debian/edm.install
+++ b/debian/edm.install
@@ -5,5 +5,4 @@ usr/share/edm/helpFiles
 etc/edm/edmObjects
 etc/edm/edmPrintDef
 etc/edm/edmPvObjects
-etc/edm/fonts.list
 etc/edm/calc.list

--- a/debian/rules
+++ b/debian/rules
@@ -134,12 +134,15 @@ install/edm::
 	cp -r $(CURDIR)/helpFiles $(datadir)/
 	find $(datadir)/helpFiles -type f -exec chmod -x {} \;
 
-	install -m 644 -t $(confdir)/edm edmMain/fonts.list
 	install -m 644 -t $(confdir)/edm edmMain/edmPrintDef
 
 install/edm-color-default::
 	install -d debian/tmp/etc/edm
 	install -m 644 edmMain/colors.list debian/tmp/etc/edm/
+
+install/edm-font-default::
+	install -d debian/tmp/etc/edm
+	install -m 644 edmMain/fonts.list debian/tmp/etc/edm/
 
 install/edm-doc::
 	install -d debian/tmp/usr/share/doc/edm/contrib


### PR DESCRIPTION
enable replacement of edm-font-default (in addition to edm-color-default) by local variants of definitions.

One can create and provide a local variant of package edm-font-default (i.e. edm-font-mydefs) to replace the default version of font definitions by the local variant. 
The d/control file of the local variant then should look like:

[...snip...]
Package: edm-font-mydefs
Architecture: all
Depends: ${misc:Depends}
Provides: edm-font
Replaces: edm-font
Conflicts: edm (<= 1.12.85-2), edm-font
Description: Extensible Display Manager
 A display manager (GUI) for the EPICS control system
 .
 This is the MYDEFS specific fonts.list intended to use with EDM.
[...snip...]